### PR TITLE
Revert "ci: change runner from ubuntu-latest to ubuntu-slim (#32)"

### DIFF
--- a/.github/workflows/docker-gitbridge.yml
+++ b/.github/workflows/docker-gitbridge.yml
@@ -115,7 +115,7 @@ jobs:
         run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }} -y
 
   merge:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' }}
     needs:
       - docker


### PR DESCRIPTION
This reverts commit 33782dff6c3416e05333d513c4e9327b1bbd6b4e. It seems that Docker buildx does not work on slim runners.